### PR TITLE
Update the transition and file transfer pages

### DIFF
--- a/docs/transfers/transfers.md
+++ b/docs/transfers/transfers.md
@@ -1,17 +1,17 @@
-# Transferring data from MGHPCC to Unity:
+# Transferring data from the Shared Cluster (GHPCC) to Unity:
 
 
-## This guide will allow you to transfer data from the MGHPCC to Unity via Globus.
+## This guide will allow you to transfer data from the Shared Cluster (GHPCC) to Unity via Globus.
 
 ### Step 1: Log in to Globus
 
 * Visit this site: [https://app.globus.org/file-manager](https://app.globus.org/file-manager)
 * Use your university credentials to log in
 
-### Step 2: Connect to the MGHPCC and Unity
+### Step 2: Connect to the Shared Cluster and Unity
 * Select the **File Manager** tab from lefthand pane
-* In the two "Collection" boxes, select the MGHPCC and Unity via their Globus identities
-    * The MGHPCC is ghpcc#ghpcc07
+* In the two "Collection" boxes, select the Shared Cluster and Unity via their Globus identities
+    * The Shared Cluster is ghpcc#ghpcc07
     * Unity is Unity
         * *more technical identifier: acda5457-9c06-4564-8375-260ba428f22a*
     * If you start typing either in the "Collection" text box, the drop-down will update and allow you to select the appropriate "Collection" (aka cluster)
@@ -30,14 +30,14 @@
 * Open the Destination directory and confirm that the file was transferred as expected.
 
 
-## This guide will allow you to send data from the MGHPCC to the Unity server using `scp` for the purposes of transitioning.
+## This guide will allow you to send data from the Shared Cluster to the Unity server using `scp` for the purposes of transitioning.
 #### Notes:
 * You will need to have set up an account on the Unity server.
-* You will need your password for the MGHPCC server (unless you are using private/public keys for logging on to this too).
+* You will need your password for the Shared Cluster server (unless you are using private/public keys for logging on to this too).
 
 ### Step 1.
-* Log in to the MGHPCC.
-* While logged into the MGHPCC, from your home directory, run `ssh-keygen -t rsa`
+* Log in to the Shared Cluster (GHPCC).
+* While logged into the Shared Cluster, from your home directory, run `ssh-keygen -t rsa`
     * This will generate a private/public key pair which is unique to each user.
     * The generator will ask you to save the keys as a specific name, and you have the option to associate a password to the keys (recommended but not required).
     * Two files will be created: NAME and NAME.pub
@@ -47,8 +47,8 @@
 * Log in to the Unity cluster portal: https://unity.rc.umass.edu/
 * Navigate to "Account Settings"
 * You will see the SSH keys that are currently linked to your account
-* Click the "+" button to add the MGHPCC key to your account.
-* Copy the entire contents of the public key (NAME.pub) from the MGHPCC generated in Step 1 into the prompt.
+* Click the "+" button to add the Shared Cluster key to your account.
+* Copy the entire contents of the public key (NAME.pub) from the Shared Cluster generated in Step 1 into the prompt.
 * Click "add key"
 * Click "Set Login Shell"
     * This will now link the two servers, allowing them to communicate
@@ -57,16 +57,16 @@
 ### Step 3.
 * Log into the Unity cluster
 * Create a file to test the connection between servers (e.g. `touch test.txt`)
-* Attempt to transfer the file from Unity to the MGHPCC:
+* Attempt to transfer the file from Unity to the Shared Cluster:
     * `scp test.txt username@ghpcc06.umassrc.org:/home/username/`
-* You will be prompted for your password to the MGHPCC - enter it here.
+* You will be prompted for your password to the Shared Cluster - enter it here.
 * If configured properly, this file should transfer immediately to the specified destination path (in this case `/home/username/`)
 
 ### Step 4.
-* Assuming that Step 3 worked and the file transferred across from Unity to the MGHPCC, you can use this to pull data across:
+* Assuming that Step 3 worked and the file transferred across from Unity to the Shared Cluster, you can use this to pull data across:
 `scp username@ghpcc06.umassrc.org:/where/files/are/you/want/* ./destination/`
 * Each time you run `scp` in this way, you will be prompted for your password.
-* **Note** that currently this only works when **logged in and running commands from Unity, not the MGHPCC.**
+* **Note** that currently this only works when **logged in and running commands from Unity, not the Shared Cluster.**
 
 
 Globus documentation provided by the Molecular Ecology and Conservation Lab, Dept. Environmental Conservation.

--- a/docs/transition.md
+++ b/docs/transition.md
@@ -1,6 +1,6 @@
 # Transitioning from the Shared Cluster to Unity
 
-_Last updated: 17 March 2023_
+_Last updated: 21 April 2023_
 
 It is our pleasure to welcome you to [Unity](https://unity.rc.umass.edu/), 
 a high performance computing cluster located at [MGHPCC](https://www.mghpcc.org/) and managed by 
@@ -11,6 +11,17 @@ Please see below for important dates and information to guide your transition to
 _For questions about the Unity transition, please attend our 
 [onboarding sessions](#onboarding-live-sessions) 
 or contact the Unity help desk at [hpc@umass.edu](mailto:hpc@umass.edu)._
+
+_In addition, we have created a new Unity User Community.
+Please sign up with your school email
+[here](https://join.slack.com/t/unity-user-community/signup).
+If you’re unable to register with your school email, please contact 
+[hpc@umass.edu](mailto:hpc@umass.edu) 
+with your preferred email address and we’ll send you a direct invite._
+
+_Once you’ve signed up, you can access the community 
+[here](https://unity-user-community.slack.com)._
+
 
 [TOC]
 
@@ -50,10 +61,7 @@ continue transferring data, you will no longer be able to run jobs or create new
 ## Onboarding Live Sessions
 
 To ensure a smooth transition from the Shared Cluster to Unity, we will hold two online 
-workshops on accessing Unity, data transfer and storage, and running jobs. Both workshops 
-will take place on Zoom (links follow each description below). Recordings and slides will 
-be available [on this page](/transition.html) after the workshops for review or if you can’t 
-attend live. 
+workshops on accessing Unity, data transfer and storage, and running jobs. Links to the recordings and slides follow each workshop description.
 
 ### Unity Onboarding Workshop Part 1: Access and Data Storage (March 31, 2023)
 
@@ -61,14 +69,18 @@ _Friday, March 31, 2023, 2:00 pm to 3:00 pm (time for questions following)_
 We will provide an overview of Unity in comparison to the Shared cluster, explain the account 
 request process for PIs/faculty and students/postdocs, and discuss storage on Unity and data 
 transfer options.  
-[**Zoom link**](https://umass-amherst.zoom.us/j/99759226495) 
+
+[**Recording link**](https://umass-my.sharepoint.com/:v:/g/personal/gstuart_umass_edu/ESGBqTjFg99Bjj5VQ0pG17ABtmvwDozDw1L85Utu2Rmpig)  
+[**Slides link**](https://bit.ly/ghpcc-to-unity)
 
 ### Unity Onboarding Workshop Part 2: Running Jobs (April 14, 2023)
 _Friday, April 14, 2023, 2:00 pm to 3:00 pm (time for questions following)_  
 We will discuss the differences between the Shared Cluster’s LSF scheduler and Unity’s Slurm 
 scheduler, introduce Unity’s partition layout, show example Slurm jobs, and demonstrate Unity’s 
 Open OnDemand portal.   
-[**Zoom link**](https://umass-amherst.zoom.us/j/92501785774) 
+
+[**Recording link**](https://umass-my.sharepoint.com/:v:/g/personal/gstuart_umass_edu/ESOfR4VMB0BEiJlqwtRMnxoBmUugUD4YUl5qkBvt0mEilQ)  
+[**Slides link**](https://bit.ly/ghpcc-to-unity-2) 
 
 ## Technical Information
 

--- a/docs/transition.md
+++ b/docs/transition.md
@@ -60,14 +60,14 @@ continue transferring data, you will no longer be able to run jobs or create new
 
 ## Onboarding Live Sessions
 
-To ensure a smooth transition from the Shared Cluster to Unity, we will hold two online 
+To ensure a smooth transition from the Shared Cluster to Unity, we held two online 
 workshops on accessing Unity, data transfer and storage, and running jobs. Links to the recordings and slides follow each workshop description.
 
 ### Unity Onboarding Workshop Part 1: Access and Data Storage (March 31, 2023)
 
 _Friday, March 31, 2023, 2:00 pm to 3:00 pm (time for questions following)_  
-We will provide an overview of Unity in comparison to the Shared cluster, explain the account 
-request process for PIs/faculty and students/postdocs, and discuss storage on Unity and data 
+We provided an overview of Unity in comparison to the Shared cluster, explained the account 
+request process for PIs/faculty and students/postdocs, and discussed storage on Unity and data 
 transfer options.  
 
 [**Recording link**](https://umass-my.sharepoint.com/:v:/g/personal/gstuart_umass_edu/ESGBqTjFg99Bjj5VQ0pG17ABtmvwDozDw1L85Utu2Rmpig)  
@@ -75,8 +75,8 @@ transfer options.
 
 ### Unity Onboarding Workshop Part 2: Running Jobs (April 14, 2023)
 _Friday, April 14, 2023, 2:00 pm to 3:00 pm (time for questions following)_  
-We will discuss the differences between the Shared Cluster’s LSF scheduler and Unity’s Slurm 
-scheduler, introduce Unity’s partition layout, show example Slurm jobs, and demonstrate Unity’s 
+We discussed the differences between the Shared Cluster’s LSF scheduler and Unity’s Slurm 
+scheduler, introduced Unity’s partition layout, showed example Slurm jobs, and demonstrated Unity’s 
 Open OnDemand portal.   
 
 [**Recording link**](https://umass-my.sharepoint.com/:v:/g/personal/gstuart_umass_edu/ESOfR4VMB0BEiJlqwtRMnxoBmUugUD4YUl5qkBvt0mEilQ)  


### PR DESCRIPTION
This PR

1. Adds Slack information and session recordings to the transition page
2. Changes "MGHPCC" to "Shared Cluster" on the file transfer page for clarity. Unity is at the MGHPCC so calling the old shared cluster the "MGHPCC" is confusing. 

Reviewers: please make sure the recording links work without logging in to UMass Amherst. I've been having difficulties with the Microsoft Stream links :( 