### PR TITLE
docs: Provide recommended scratch space workflow

### DIFF
--- a/docs/managing-files/hpc-workspace.md
+++ b/docs/managing-files/hpc-workspace.md
@@ -73,6 +73,9 @@ username@login2:~$ ws_list
 username@login2:~$
 ```
 
+!!! tip
+    We encourage releasing workspaces when they are no longer needed to facilitate optimal scratch space usage.
+
 !!! important 
     Releasing a workspace does not delete the data immediately.
     The deletion of the workspace can take place at any time once it's released.

--- a/docs/managing-files/hpc-workspace.md
+++ b/docs/managing-files/hpc-workspace.md
@@ -74,7 +74,7 @@ username@login2:~$
 ```
 
 !!! tip
-    We encourage releasing workspaces when they are no longer needed to facilitate optimal scratch space usage.
+    Please release workspaces when they are no longer needed to help optimize scratch space for all Unity users.
 
 !!! important 
     Releasing a workspace does not delete the data immediately.


### PR DESCRIPTION
This adds a note to users to recommend that they delete their workspace as soon as possible to allow for better scratch space utilization.